### PR TITLE
Fix Joyn on Kodi Matrix

### DIFF
--- a/resources/lib/xbmc_helper.py
+++ b/resources/lib/xbmc_helper.py
@@ -5,7 +5,7 @@ from distutils.version import LooseVersion
 from io import open as io_open
 from datetime import datetime, timedelta
 from xbmc import translatePath, executeJSONRPC, executebuiltin, getCondVisibility, getInfoLabel, getSkinDir, log, \
-    sleep as xbmc_sleep, LOGERROR, LOGDEBUG, LOGNOTICE
+    sleep as xbmc_sleep, LOGERROR, LOGDEBUG, LOGINFO
 from xbmcplugin import setContent, endOfDirectory, addDirectoryItems, setPluginCategory
 from xbmcvfs import mkdirs, exists, listdir, delete
 from xbmcgui import Dialog, NOTIFICATION_ERROR
@@ -313,7 +313,7 @@ class xbmc_helper(Singleton):
 		self._log(compat._format(format, *args), LOGERROR)
 
 	def log_notice(self, format, *args):
-		self._log(compat._format(format, *args), LOGNOTICE)
+		self._log(compat._format(format, *args), LOGINFO)
 
 	def log_debug(self, format, *args):
 		if self.get_bool_setting('debug_mode') is True:
@@ -321,7 +321,7 @@ class xbmc_helper(Singleton):
 		elif self.kodi_debug is True:
 			self._log(compat._format(format, *args), LOGDEBUG)
 
-	def _log(self, msg, level=LOGNOTICE):
+	def _log(self, msg, level=LOGINFO):
 		log(compat._encode(compat._format('[{}] {}', self.get_addon_version(), msg)), level)
 
 	def translation(self, id):


### PR DESCRIPTION
LOGNOTICE has been removed and one should use LOGINFO instead. This fixes the following issue:
```
2020-12-27 18:26:43.279 T:13901   ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'ImportError'>
                                                   Error Contents: cannot import name 'LOGNOTICE' from 'xbmc' (unknown location)
                                                   Traceback (most recent call last):
                                                     File "/storage/.kodi/addons/plugin.video.joyn/service.py", line 4, in <module>
                                                       from resources.lib.xbmc_helper import xbmc_helper
                                                     File "/storage/.kodi/addons/plugin.video.joyn/resources/lib/xbmc_helper.py", line 7, in <module>
                                                       from xbmc import translatePath, executeJSONRPC, executebuiltin, getCondVisibility, getInfoLabel, getSkinDir, log, \
                                                   ImportError: cannot import name 'LOGNOTICE' from 'xbmc' (unknown location)
                                                   -->End of Python script error report<--
                                                   
2020-12-27 18:26:43.532 T:13901    INFO <general>: Python interpreter stopped
```